### PR TITLE
Fixes in tooltip.

### DIFF
--- a/src/components/LetterBox.tsx
+++ b/src/components/LetterBox.tsx
@@ -66,15 +66,17 @@ export class LetterBox extends React.Component<LetterBoxProps, undefined> {
             let ttPause = {};
             let ttChange = {};
             if (this.props.options.showTooltips) {
-                let upgradeCost = (this.props.letter.level + 1);
+                let upgradeAmount = 1;
                 if (this.props.altShiftState.shiftDown) {
-                    upgradeCost *= 10;
+                    upgradeAmount = 10;
                 }
                 else if (this.props.altShiftState.altDown) {
-                    upgradeCost *= 100;
+                    upgradeAmount = 100;
                 }
+                let upgradeCost = (this.props.letter.level * upgradeAmount);
+                upgradeCost += ((upgradeAmount * (upgradeAmount + 1)) / 2);
                 ttUpgradeOnce = {
-                    "data-tip": `Buy 1 auto converter for ${upgradeCost==1?upgradeCost : upgradeCost.toString() + ' of'} next letter${upgradeCost>1?'s':''}<br>` +
+                    "data-tip": `Buy ${upgradeAmount} autoconverter${upgradeAmount>1?'s':''} for ${upgradeCost==1?upgradeCost : upgradeCost.toString() + ' of'} next letter${upgradeCost>1?'s':''}<br>` +
                     "Hold shift and click to buy 10<br>" +
                     "Hold alt and click to buy 100<br>" +
                     `Each autoconverter will convert 10 of the previous letter to ${this.props.letter.mult} of this letter each second`,


### PR DESCRIPTION
When pressing shift or alt, the cost was not calculated correctly in the tooltip and the amount was not adjusted.

Previously the cost for multiple levels was calculated by multiplying the cost for the next level by the amount of upgrades.

This was not correctly because it didn't account for the rising costs each level.

This fixes the calculation by multiplying the base cost by the amount of upgrades.
and adding the Triangular number for the amount of upgrades.

- for 1 upgrade, this number is 1
- for 10 upgrades, this number is 55
- for 100 upgrades, this number is 5050

for any amount of upgrades, this number is `( n ( n + 1 ) ) / 2` where n is the number of upgrades.

More info about the triangular numbers: http://mathcentral.uregina.ca/qq/database/qq.02.06/jo1.html